### PR TITLE
Adding titlePath in bridge to handle reporting of test failures

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -40,6 +40,7 @@
 
       if (test) {
         data.title = test.title;
+        data.titlePath = test.titlePath();
         data.fullTitle = test.fullTitle();
         data.state = test.state;
         data.duration = test.duration;

--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
 
     // Hook on Phantomjs Mocha reporter events.
     phantomjs.on('mocha.*', function(test) {
-      var name, fullTitle, slow, err;
+      var name, titlePath, fullTitle, slow, err;
       var evt = this.event.replace('mocha.', '');
 
       if (evt === 'end') {
@@ -57,6 +57,11 @@ module.exports = function(grunt) {
 
       // Expand test values (and façace the Mocha test object)
       if (test) {
+        titlePath = test.titlePath;
+        test.titlePath = function() {
+          return titlePath;
+        };
+
         fullTitle = test.fullTitle;
         test.fullTitle = function() {
           return fullTitle;


### PR DESCRIPTION
This code changes resolve an issue where tests that fail report

```
  1 failing

Fatal error: test.titlePath is not a function
```


After these changes I get the expected trace.
```
  1 failing

  1) Fetch Test Suite
       When loading modules by name
         When fetching a single module called `like`
           then then result is an object:
     expected [ Array(1) ] to be an object
  AssertionError
  assert
  an
  chainableMethodWrapper
  
  runHandler@http://localhost:54232/node_modules/spromise/dist/spromise.min.js:1:5831
  http://localhost:54232/node_modules/spromise/dist/spromise.min.js:1:5718
  c@http://localhost:54232/node_modules/spromise/dist/spromise.min.js:1:5178
  _runTask@http://localhost:54232/node_modules/spromise/dist/spromise.min.js:1:6923
  http://localhost:54232/node_modules/spromise/dist/spromise.min.js:1:6881
```

This fixes https://github.com/disqus/grunt-mocha/issues/6