### PR TITLE
ci(node): Update node versions to run tests against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - 4
   - 6
-  - 7
+  - 8
+  - 9
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Node 7 is deprecated and Node 8 is the new LTS now. This patch updates Travis config to match this.