### PR TITLE
 ci(node): Update node versions to run tests against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - 4
   - 6
   - 8
-  - 9
+  - 10
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Node 4 is deprecated and Node 10 just replaced 9 as the new LTS. This patch updates Travis config to match this.